### PR TITLE
Secret Change Monitoring in Kubernetes Namespace 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,22 @@
-FROM docker.io/alpine:latest 
+FROM golang:1.22
 
-ENV CERT_FILE=/mg/secret/ssc/tls.crt \
-    CLONE_PATH=/tmp/clone \
-    VAULT_TOKEN="" \
-    VAULT_KV="" \
-    REPO_URL=""\ 
-    SSL_CERT_FILE=/tmp/cert/ca.crt
-    
-COPY . /
+# Set destination for COPY
+WORKDIR /app
+
+# Download Go modules
+COPY go.mod go.sum ./
+RUN go mod download
+
+# Copy the source code. Note the slash at the end, as explained in
+# https://docs.docker.com/reference/dockerfile/#copy
+COPY *.go ./
+
+# Build
+RUN CGO_ENABLED=0 GOOS=linux go build -o /raven
+
 COPY files/start /start
+RUN chmod +x /start
+
+# Run
 USER 1001
 ENTRYPOINT ["/start"]

--- a/k8s.go
+++ b/k8s.go
@@ -6,17 +6,33 @@ import (
 	"fmt"
 	"github.com/hashicorp/vault/api"
 	log "github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	"log/slog"
 	"os"
+	"os/signal"
 	"reflect"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 )
+
+type Watcher struct {
+	Logger    *slog.Logger
+	ClientSet kubernetes.Interface
+	Namespace string
+}
+
+func NewWatcher(logger *slog.Logger, clientSet kubernetes.Interface, namespace string) *Watcher {
+	logger.Info("Initialising kubernetes watcher")
+	return &Watcher{Logger: logger, ClientSet: clientSet, Namespace: namespace}
+}
 
 func applyAnnotations(dataFields *api.Secret, config config) map[string]string {
 
@@ -130,18 +146,18 @@ func NewSecretWithContents(contents SecretContents, config config) (secret v1.Se
 	return secret
 }
 
-func initk8sServiceAccount() *kubernetes.Clientset {
+func NewKubernetesClient() *kubernetes.Clientset {
 	// creates the in-cluster config
 
 	config, err := rest.InClusterConfig()
 	if err != nil {
-		log.WithFields(log.Fields{"error": err}).Info("initk8sServiceAccount incluster config failed")
+		log.WithFields(log.Fields{"error": err}).Info("NewKubernetesClient incluster config failed")
 
 	}
 	// creates the clientset
 	Clientset, err := kubernetes.NewForConfig(config)
 	if err != nil {
-		log.WithFields(log.Fields{"error": err}).Info("initk8sServiceAccount clientset failed")
+		log.WithFields(log.Fields{"error": err}).Info("NewKubernetesClient clientset failed")
 	}
 	return Clientset
 
@@ -231,4 +247,160 @@ func monitorMessages(watchlist []string) {
 			}
 		}
 	}
+}
+
+func (app *Watcher) MonitorNamespaceForSecretChange() {
+	ctx := context.Background()
+
+	app.Logger.Info("Started monitoring for secrets in kubernetes", slog.String("namespace", app.Namespace))
+	theSecretWatcher, err := app.ClientSet.CoreV1().Secrets(app.Namespace).Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		app.Logger.Error("Failed to watch for secrets", slog.String("error", err.Error()), slog.String("namespace", app.Namespace))
+	}
+
+	// Create a channel to receive signals to stop watching
+	stopCh := make(chan struct{})
+	signalCh := make(chan os.Signal, 1)
+	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
+
+	// Start watching for events in a separate goroutine
+
+	go func() {
+		defer close(stopCh)
+		for {
+			select {
+			case event, ok := <-theSecretWatcher.ResultChan():
+				if !ok {
+					app.Logger.Error("Failed to read event from watcher", slog.String("error", "channel closed"), slog.String("namespace", app.Namespace), slog.String("type", "error"))
+					return
+				}
+				secret, ok := event.Object.(*corev1.Secret)
+				if !ok {
+					fmt.Println("Unexpected object type")
+					continue
+				}
+				switch event.Type {
+				case "ADDED":
+					app.Logger.Debug("secret was added", slog.String("secret", secret.Name), slog.String("namespace", secret.Namespace), slog.String("type", "added"))
+					val, managedByRaven := secret.ObjectMeta.Labels["managedBy"]
+
+					recentlyAdded := false
+					for _, mf := range secret.ObjectMeta.ManagedFields {
+						since := time.Since(mf.Time.Time)
+						if since.Minutes() < 3 {
+							recentlyAdded = true
+						}
+
+					}
+
+					// If the key exists
+					app.Logger.Debug("managedByRaven", slog.String("managedByRaven", strconv.FormatBool(managedByRaven)))
+					if val == "raven" && recentlyAdded {
+						app.Logger.Info("secret was added and is managed by Raven", slog.String("secret", secret.Name), slog.String("namespace", secret.Namespace), slog.String("type", "added"))
+						app.checkResources(secret, "added", ctx)
+					} else {
+						app.Logger.Debug("secret was added but does not match", slog.String("secret", secret.Name), slog.String("namespace", secret.Namespace), slog.String("type", "added"))
+					}
+				case "MODIFIED":
+					app.Logger.Debug("secret was added", slog.String("secret", secret.Name), slog.String("namespace", secret.Namespace), slog.String("type", "modified"))
+
+					val, _ := secret.ObjectMeta.Labels["managedBy"]
+
+					recentlyAdded := false
+					for _, mf := range secret.ObjectMeta.ManagedFields {
+						since := time.Since(mf.Time.Time)
+						if since.Minutes() < 3 {
+							recentlyAdded = true
+						}
+
+					}
+
+					if val == "raven" && recentlyAdded {
+						app.Logger.Info("secret was updated and is managed by Raven", slog.String("secret", secret.Name), slog.String("namespace", secret.Namespace), slog.String("type", "modified"))
+						app.Logger.Info("secret was added", slog.String("secret", secret.Name), slog.String("namespace", secret.Namespace), slog.String("type", "added"))
+						app.checkResources(secret, "modified", ctx)
+
+					} else {
+						app.Logger.Debug("secret was updated but does not match", slog.String("secret", secret.Name), slog.String("namespace", secret.Namespace), slog.String("type", "added"))
+					}
+				case "DELETED":
+					app.Logger.Info("secret was deleted", slog.String("secret", secret.Name), slog.String("namespace", secret.Namespace), slog.String("type", "deleted"))
+					fmt.Printf("Secret deleted: %s\n", secret.Name)
+				default:
+					fmt.Printf("Unknown event type: %s\n", event.Type)
+				}
+			case <-stopCh:
+				app.Logger.Info("we're stopping... why?")
+				// Stop watching
+				return
+			}
+		}
+	}()
+}
+func (app *Watcher) checkResources(secret *corev1.Secret, eventType string, ctx context.Context) {
+	app.Logger.Info("Checking resources", slog.String("secret", secret.Name), slog.String("namespace", secret.Namespace), slog.String("eventType", eventType))
+
+	// Check StatefulSets
+	allStateFulSets, err := app.ClientSet.AppsV1().StatefulSets(app.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		fmt.Println(err)
+	}
+	for _, stateful := range allStateFulSets.Items {
+		for _, v := range stateful.Spec.Template.Spec.Volumes {
+			app.Logger.Debug("Checking StatefulSet", slog.Any("annotation", stateful))
+			if v.Secret.SecretName == secret.Name && stateful.Spec.Template.Annotations["norsk-tipping.no/lastUUIDTriggeredRestart"] != string(secret.ObjectMeta.UID) {
+				app.TriggerRollout(nil, &stateful, secret)
+			}
+		}
+	}
+
+	// Check Deployments
+	allDeployments, err := app.ClientSet.AppsV1().Deployments(app.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		fmt.Println(err)
+	}
+	for _, dep := range allDeployments.Items {
+		for _, v := range dep.Spec.Template.Spec.Volumes {
+			app.Logger.Debug("Checking Deployment", slog.Any("annotation", v))
+			if v.Secret.SecretName == secret.Name {
+				app.Logger.Info("Found match", slog.String("secret", secret.Name), slog.String("namespace", secret.Namespace), slog.String("eventType", eventType), slog.String("UID", string(secret.ObjectMeta.UID)))
+				app.TriggerRollout(&dep, nil, secret)
+			}
+		}
+	}
+}
+
+func (app *Watcher) TriggerRollout(deployment *appsv1.Deployment, statefulset *appsv1.StatefulSet, secret *v1.Secret) {
+
+	if deployment != nil {
+
+		app.Logger.Info("Found match. Need to refresh deployment", slog.String("deployment", deployment.Name), slog.String("namespace", deployment.Namespace), slog.Any("labels", deployment.ObjectMeta.Labels))
+		if deployment.Spec.Template.ObjectMeta.Annotations == nil {
+			deployment.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+		}
+
+		deployment.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = metav1.Now().String()
+		deployment.Spec.Template.ObjectMeta.Annotations["openshift.openshift.io/restartedAt"] = metav1.Now().String()
+		deployment.Spec.Template.ObjectMeta.Annotations["norsk-tipping.no/lastUUIDTriggeredRestart"] = string(secret.ObjectMeta.UID)
+		_, err := app.ClientSet.AppsV1().Deployments(app.Namespace).Update(context.Background(), deployment, metav1.UpdateOptions{})
+		if err != nil {
+			app.Logger.Error("failed to update deployment", slog.String("error", err.Error()), slog.String("deployment", deployment.Name), slog.String("namespace", deployment.Namespace))
+
+		}
+		app.Logger.Info("Rollout restart triggered for deployment in namespace", slog.String("deployment", deployment.Name), slog.String("namespace", deployment.Namespace))
+	} else if statefulset != nil {
+		app.Logger.Info("Found match. Need to refresh statefulset", slog.String("statefulset", statefulset.Name), slog.String("namespace", statefulset.Namespace))
+		if statefulset.Spec.Template.ObjectMeta.Annotations == nil {
+			statefulset.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+		}
+		statefulset.Spec.Template.ObjectMeta.Annotations["norsk-tipping.no/RestartTriggerUUID"] = string(secret.ObjectMeta.UID)
+		statefulset.Spec.Template.ObjectMeta.Annotations["openshift.openshift.io/restartedAt"] = metav1.Now().String()
+		statefulset.Spec.Template.ObjectMeta.Annotations["kubectl.kubernetes.io/restartedAt"] = metav1.Now().String()
+		_, err := app.ClientSet.AppsV1().StatefulSets(app.Namespace).Update(context.Background(), statefulset, metav1.UpdateOptions{})
+		if err != nil {
+			app.Logger.Error("failed to update statefulset", slog.String("error", err.Error()), slog.String("deployment", statefulset.Name), slog.String("namespace", statefulset.Namespace))
+		}
+		app.Logger.Info("Rollout restart triggered for statefulset in namespace", slog.String("statefulSet", statefulset.Name), slog.String("namespace", statefulset.Namespace))
+	}
+
 }

--- a/raven.go
+++ b/raven.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 
@@ -156,8 +157,17 @@ func main() {
 
 		kubernetesMonitor := os.Getenv("KUBERNETESMONITOR")
 		kubernetesRemove := os.Getenv("KUBERNETESREMOVE")
+		kubernetesDoRollout := os.Getenv("KUBERNETES_ROLLOUT")
+
 		if kubernetesMonitor == "true" || kubernetesRemove == "true" {
-			newConfig.Clientset = initk8sServiceAccount()
+			newConfig.Clientset = NewKubernetesClient()
+		}
+
+		if kubernetesDoRollout == "true" {
+			theLogger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+			newClient := NewKubernetesClient()
+			w := NewWatcher(theLogger, newClient, *destEnv)
+			w.MonitorNamespaceForSecretChange()
 		}
 
 		log.WithFields(log.Fields{"config": newConfig}).Debug("Setting newConfig variables. preparing to run. ")

--- a/reconcile.go
+++ b/reconcile.go
@@ -13,7 +13,6 @@ import (
 
 /*
 HarvestRipeSecrets() checks local files based on RipeSecrets returned from PickRipeSecrets() and marks them for deletion.
-
 */
 func HarvestRipeSecrets(RipeSecrets []string, config config) {
 	if len(RipeSecrets) > 0 {
@@ -34,12 +33,12 @@ func HarvestRipeSecrets(RipeSecrets []string, config config) {
 		}
 		kubernetesremove := os.Getenv("KUBERNETESREMOVE")
 		if kubernetesremove == "true" {
-			config.Clientset = initk8sServiceAccount()
+			config.Clientset = NewKubernetesClient()
 			kubernetesSecretList, err := kubernetesSecretList(config.Clientset, config.destEnv)
 			if err != nil {
 				log.WithFields(log.Fields{"err": err}).Error("harvestripesecret secretlist fetch failed")
 			}
-			config.Clientset = initk8sServiceAccount()
+			config.Clientset = NewKubernetesClient()
 			kubernetesRemove(RipeSecrets, kubernetesSecretList, config.Clientset, config.destEnv)
 			log.WithFields(log.Fields{}).Debug("HarvestRipeSecrets done")
 		}
@@ -54,8 +53,6 @@ func SerializeAndWriteToFile(SealedSecret *sealedSecretPkg.SealedSecret, fullPat
 		WriteErrorToTerminationLog(err.Error())
 	}
 
-
-
 	options := k8sJson.SerializerOptions{
 		Yaml:   true,
 		Pretty: true,
@@ -69,8 +66,6 @@ func SerializeAndWriteToFile(SealedSecret *sealedSecretPkg.SealedSecret, fullPat
 	}
 
 }
-
-
 
 /*
 ensurePathandreturnWritePath:


### PR DESCRIPTION
Key changes include:

1. **Secret Event Monitoring**: The `Watcher` struct now includes a method to watch for events related to Kubernetes secrets. This method listens for `ADD`, `UPDATE`, and `DELETE` events and logs the event type and secret name.

2. **Resource Checking**: Upon detection of a secret event, the `checkResources` method is invoked. This method checks both `StatefulSets` and `Deployments` for any volumes that use the changed secret. If a match is found, a rollout is triggered.

3. **Rollout Triggering**: The `TriggerRollout` method has been implemented to refresh either a `Deployment` or a `StatefulSet` that uses the changed secret. The method updates the annotations of the `Deployment` or `StatefulSet` to trigger a rollout.

4. **Dockerfile Update**: The Dockerfile has been updated to use Golang 1.22 and includes steps to download Go modules, copy the source code, build the application, and set the entry point.

This feature enhances the application's ability to respond to changes in Kubernetes secrets, ensuring that any `StatefulSets` or `Deployments` using a changed secret are promptly updated.

Please review the changes and provide any feedback.